### PR TITLE
Dependency and security fixes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -131,6 +131,7 @@ jobs:
           disable-sudo: true
           egress-policy: block
           allowed-endpoints: >
+            cdn.fwupd.org:443
             conda.anaconda.org:443
             coveralls.io:443
             files.pythonhosted.org:443

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -149,6 +149,7 @@ jobs:
         with:
           cache-downloads: true
           cache-environment: true
+          cache-environment-key: conda-Python${{ matrix.python-version }}-${{ hashFiles('environment-dev.yml') }}
           environment-file: environment-dev.yml
           create-args: >-
             python=${{ matrix.python-version }}

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,19 +2,20 @@
 Changelog
 =========
 
-..
-    `Unreleased <https://github.com/Ouranosinc/xsdba>`_ (latest)
-    ------------------------------------------------------------
+`Unreleased <https://github.com/Ouranosinc/xsdba>`_ (latest)
+------------------------------------------------------------
 
-    Contributors:
+Contributors: Trevor James Smith (:user:`Zeitsperre`).
 
-    Changes
-    ^^^^^^^
-    * No change.
-
-    Fixes
-    ^^^^^
-    * No change.
+Fixes
+^^^^^
+* Packaging and security adjustments. (:pull:`106`):
+    * Added `deptry`, `codespell`, `vulture`, and `yamllint` to the dev dependencies.
+    * Added a few transitive dependencies (`packaging`, `pandas`) to the core dependencies.
+    * Added `fastnanquantile` to the `dev` dependencies (to be placed in an `extras` recipe for `xsdba` v0.4.0+).
+    * Configured `deptry` to handle optional imports.
+    * A new Makefile command `lint/security` has been added (called when running `$ make lint`).
+    * Updated `tox.ini` with new linting dependencies.
 
 .. _changes_0.3.1:
 

--- a/Makefile
+++ b/Makefile
@@ -56,13 +56,19 @@ lint/flake8: ## check style with flake8
 	python -m ruff check src/xsdba tests
 	python -m flake8 --config=.flake8 src/xsdba tests
 	python -m numpydoc lint src/xsdba/**.py
+	codespell src/xclim tests docs
 
 lint/black: ## check style with black
 	python -m black --check src/xsdba tests
 	python -m blackdoc --check src/xsdba docs
 	python -m isort --check src/xsdba tests
+	python -m yamllint --config-file=.yamllint.yaml src/xsdba
 
-lint: lint/flake8 lint/black ## check style
+lint/security: ## check dependencies
+	python -m deptry src/xsdba
+	python -m vulture src/xsdba tests
+
+lint: lint/flake8 lint/black lint/security ## check style
 
 test: ## run tests quickly with the default Python
 	python -m pytest

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -19,14 +19,17 @@ dependencies:
 - xarray >=2023.11.0
 - yamale >=5.0.0
 # Extras
+- fastnanquantile >=0.0.2
 - pot >=0.9.4
 - xclim >=0.55.1
 # Dev tools and testing
 - black ==25.1.0
 - blackdoc ==0.3.9
 - bump-my-version >=0.30.1
+- codespell >=2.4.1
 - coverage >=7.5.0
 - coveralls >=4.0.1
+- deptry >=0.23.0
 - flake8 >=7.1.1
 - flake8-rst-docstrings >=0.3.0
 - flit >=3.10.1,<4.0
@@ -36,10 +39,12 @@ dependencies:
 - pip >=24.3.1
 - pooch >=1.8.0
 - pre-commit >=3.5.0
-- pytest <8.0.0
+- pytest >=8.0.0,<9.0.0
 - pytest-cov >=5.0.0
 - pytest-xdist >=3.2.0
 - ruff >=0.9.0
 - tox >=4.24.1
+- vulture >=2.14
 - watchdog >=4.0.0
 - xdoctest>=1.1.5
+- yamllint >=1.35.1

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -8,7 +8,6 @@ dependencies:
 - cf_xarray >=0.10.0 # not sure if we need to be that strict
 - cftime >=1.4.1
 - dask >=2024.8.1
-- h5netcdf >=1.3.0
 - jsonpickle >=3.1.0
 - numba >=0.54.1
 - numpy >=1.23.0,<2.0 # to accommodate numba
@@ -17,7 +16,6 @@ dependencies:
 - statsmodels >=0.14.2
 - typer >=0.12.3
 - xarray >=2023.11.0
-- yamale >=5.0.0
 # Extras
 - fastnanquantile >=0.0.2
 - pot >=0.9.4
@@ -33,6 +31,7 @@ dependencies:
 - flake8 >=7.1.1
 - flake8-rst-docstrings >=0.3.0
 - flit >=3.10.1,<4.0
+- h5netcdf >=1.3.0
 - isort ==6.0.0
 - mypy >=1.14.1
 - numpydoc >=1.8.0

--- a/environment-docs.yml
+++ b/environment-docs.yml
@@ -15,7 +15,7 @@ dependencies:
 - sphinx >=7.1.0,<8.2.0 # pinned until nbsphinx supports sphinx 8.2
 - sphinx-autobuild >=2024.4.16
 - sphinx-autodoc-typehints
-- sphinx-codeautolink >=0.16.2
+- sphinx-codeautolink
 - sphinx-copybutton
 - sphinx-intl
 - sphinx-mdinclude

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,10 +39,13 @@ dependencies = [
   "cf_xarray>=0.10.0",
   "cftime >=1.4.1",
   "dask >=2024.8.1",
+  "filelock >=3.14.0",
   "h5netcdf>=1.3.0",
   "jsonpickle >=3.1.0",
   "numba >=0.54.1",
   "numpy >=1.23.0,<2.0",
+  "packaging",
+  "pandas >=2.2.0",
   "pint>=0.24.3",
   "scipy >=1.9.0",
   "statsmodels >=0.14.2",
@@ -57,7 +60,10 @@ dev = [
   "black ==25.1.0",
   "blackdoc ==0.3.9",
   "bump-my-version >=0.30.1",
+  "codespell >=2.4.1",
   "coverage >=7.5.0",
+  "deptry >=0.23.0",
+  "fastnanquantile >=0.0.2",
   "flake8 >=7.1.1",
   "flake8-rst-docstrings >=0.3.0",
   "flit >=3.10.1,<4.0",
@@ -68,14 +74,16 @@ dev = [
   "pooch >=1.8.0",
   "POT >=0.9.4",
   "pre-commit >=3.5.0",
-  "pytest <9.0.0",
+  "pytest >=8.0.0,<9.0.0",
   "pytest-cov >=5.0.0",
   "pytest-xdist >=3.2.0",
   "ruff >=0.9.0",
   "tox >=4.24.1",
+  "vulture >=2.14",
   "watchdog >=4.0.0",
-  "xclim >= 0.55.1",
-  "xdoctest>=1.1.5"
+  "xclim >=0.55.1",
+  "xdoctest >=1.1.5",
+  "yamllint >=1.35.1"
 ]
 docs = [
   # Documentation and examples
@@ -185,6 +193,7 @@ values = [
 ]
 
 [tool.codespell]
+skip = '*docs/_build,*docs/references.bib,*.gz,*.png,*.svg,*.whl'
 ignore-words-list = "astroid,hanel,indx,lond,ot,socio-economic"
 
 [tool.coverage.paths]
@@ -194,6 +203,21 @@ source = ["src/xsdba/", "*/site-packages/xsdba/"]
 omit = ["tests/*.py"]
 relative_files = true
 source = ["xsdba"]
+
+[tool.deptry]
+extend_exclude = ["docs"]
+ignore_notebooks = true
+pep621_dev_dependency_groups = ["all", "dev", "docs"]
+
+[tool.deptry.package_module_name_map]
+"scikit-learn" = "sklearn"
+"POT" = "ot"
+
+[tool.deptry.per_rule_ignores]
+DEP001 = ["SBCK"]
+DEP002 = ["h5netcdf", "yamale"] # are these core deps?
+DEP003 = ["rich"]
+DEP004 = ["fastnanquantile", "ot", "pooch", "xclim"] # remove some of these in xsdba>=0.4.0
 
 [tool.flit.sdist]
 include = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ dev = [
   "flake8 >=7.1.1",
   "flake8-rst-docstrings >=0.3.0",
   "flit >=3.10.1,<4.0",
+  "h5netcdf >=1.3.0",
   "isort ==6.0.1",
   "mypy >=1.14.1",
   "numpydoc >=1.8.0",
@@ -96,7 +97,7 @@ docs = [
   "sphinx >=7.1.0,<8.2.0", # pinned until nbsphinx supports sphinx 8.2
   "sphinx-autobuild >=2024.4.16",
   "sphinx-autodoc-typehints",
-  "sphinx-codeautolink >=0.16.2",
+  "sphinx-codeautolink",
   "sphinx-copybutton",
   "sphinx-intl",
   "sphinx-mdinclude",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,6 @@ dependencies = [
   "cftime >=1.4.1",
   "dask >=2024.8.1",
   "filelock >=3.14.0",
-  "h5netcdf>=1.3.0",
   "jsonpickle >=3.1.0",
   "numba >=0.54.1",
   "numpy >=1.23.0,<2.0",
@@ -51,7 +50,6 @@ dependencies = [
   "statsmodels >=0.14.2",
   "typer >=0.12.3",
   "xarray >=2023.11.0",
-  "yamale >=5.0.0"
 ]
 
 [project.optional-dependencies]
@@ -215,7 +213,6 @@ pep621_dev_dependency_groups = ["all", "dev", "docs"]
 
 [tool.deptry.per_rule_ignores]
 DEP001 = ["SBCK"]
-DEP002 = ["h5netcdf", "yamale"] # are these core deps?
 DEP003 = ["rich"]
 DEP004 = ["fastnanquantile", "ot", "pooch", "xclim"] # remove some of these in xsdba>=0.4.0
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ dependencies = [
   "scipy >=1.9.0",
   "statsmodels >=0.14.2",
   "typer >=0.12.3",
-  "xarray >=2023.11.0",
+  "xarray >=2023.11.0"
 ]
 
 [project.optional-dependencies]

--- a/tox.ini
+++ b/tox.ini
@@ -22,11 +22,15 @@ skip_install = True
 deps =
     black ==25.1.0
     blackdoc ==0.3.9
+    codespell >=2.4.1
+    deptry >=0.23.0
     isort ==6.0.0
     flake8 >=7.1.1
     flake8-rst-docstrings >=0.3.0
-    ruff >=0.9.0
     numpydoc >=1.8.0
+    ruff >=0.9.0
+    vulture >=2.14
+    yamllint >=1.35.1
 commands =
     make lint
 allowlist_externals =


### PR DESCRIPTION
<!-- Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
  - This PR fixes #xyz
- [ ] (If applicable) Documentation has been added / updated (for bug fixes / features).
- [ ] (If applicable) Tests have been added.
- [x] CHANGELOG.rst has been updated (with summary of main changes).
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added.

### What kind of change does this PR introduce?

* Adds `deptry`, `codespell`, `vulture`, and `yamllint` to the dev dependencies.
* Adds a few transitive dependencies to the core dependencies.
* Adds `fastnanquantile` to the `dev` dependencies (to be placed in an `extras` recipe for `xsdba` v0.4.0+).
* Configures `deptry` to handle optional imports.
* A new Makefile command `lint/security` has been added (called when running `$ make lint`).
* Updates `tox.ini` with new linting dependencies.

### Does this PR introduce a breaking change?

Technically, yes. Core dependencies have been modified. Some `dev` dependencies should be set into an `extras` recipe before the next minor version.

### Other information:

https://github.com/codespell-project/codespell
https://deptry.com/
https://github.com/jendrikseipp/vulture
https://github.com/adrienverge/yamllint

One thing I'm wondering: do we require `h5netcdf` and `yamale` in the core dependencies? 