### PR TITLE
Fix nan handling in escore

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,19 +2,18 @@
 Changelog
 =========
 
-..
-    `Unreleased <https://github.com/Ouranosinc/xsdba>`_ (latest)
-    ------------------------------------------------------------
+`Unreleased <https://github.com/Ouranosinc/xsdba>`_ (latest)
+------------------------------------------------------------
 
-    Contributors:
+Contributors: Éric Dupuis (:user:`coxipi`)
 
-    Changes
-    ^^^^^^^
-    * No change.
+Changes
+^^^^^^^
+* No change.
 
-    Fixes
-    ^^^^^
-    * No change.
+Fixes
+^^^^^
+* ``xsdba.processing.escore`` now correctly handles all-nan slices.  (:issue:`1982` the issue is from `xclim`, need to change this)
 
 .. _changes_0.3.1:
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,7 +13,7 @@ Changes
 
 Fixes
 ^^^^^
-* ``xsdba.processing.escore`` now correctly handles all-nan slices.  (:issue:`1982` the issue is from `xclim`, need to change this)
+* ``xsdba.processing.escore`` now correctly handles all-nan slices.  (:issue:`109`, :pull:`108`).
 
 .. _changes_0.3.1:
 

--- a/src/xsdba/nbutils.py
+++ b/src/xsdba/nbutils.py
@@ -364,13 +364,15 @@ def _escore(tgt, sim, out):
 
     n1 = sim.shape[1]
     n2 = tgt.shape[1]
+    if 0 in [n1, n2]:
+        out[0] = np.nan
+    else:
+        sXY = _correlation(tgt, sim)
+        sXX = _autocorrelation(tgt)
+        sYY = _autocorrelation(sim)
 
-    sXY = _correlation(tgt, sim)
-    sXX = _autocorrelation(tgt)
-    sYY = _autocorrelation(sim)
-
-    w = n1 * n2 / (n1 + n2)
-    out[0] = w * (sXY + sXY - sXX - sYY) / 2
+        w = n1 * n2 / (n1 + n2)
+        out[0] = w * (sXY + sXY - sXX - sYY) / 2
 
 
 @njit(

--- a/src/xsdba/processing.py
+++ b/src/xsdba/processing.py
@@ -470,7 +470,8 @@ def escore(
         input_core_dims=[[pts_dim, obs_dim], [pts_dim, new_dim]],
         output_dtypes=[sim.dtype],
         dask="parallelized",
-    )
+        vectorize=True,
+    ).mean()
 
     out.name = "escores"
     out = out.assign_attrs(

--- a/src/xsdba/processing.py
+++ b/src/xsdba/processing.py
@@ -471,7 +471,7 @@ def escore(
         output_dtypes=[sim.dtype],
         dask="parallelized",
         vectorize=True,
-    ).mean()
+    )
 
     out.name = "escores"
     out = out.assign_attrs(

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -145,8 +145,8 @@ def test_escore():
     x = np.array([1, 4, 3, 6, 4, 7, 5, 8, 4, 5, 3, 7]).reshape(2, 6)
     y = np.array([6, 6, 3, 8, 5, 7, 3, 7, 3, 6, 4, 3]).reshape(2, 6)
 
-    x = xr.DataArray(x, dims=("variables", "time"))
-    y = xr.DataArray(y, dims=("variables", "time"))
+    x = xr.DataArray(x, dims=("variables", "time")).astype(np.float64)
+    y = xr.DataArray(y, dims=("variables", "time")).astype(np.float64)
 
     # Value taken from escore of Cannon's MBC R package.
     out = escore(x, y)


### PR DESCRIPTION
<!-- Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
  - This PR fixes #xyz
- [ ] (If applicable) Documentation has been added / updated (for bug fixes / features).
- [ ] (If applicable) Tests have been added.
- [x] CHANGELOG.rst has been updated (with summary of main changes).
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added.

### What kind of change does this PR introduce?

* `_escore` returns np.nan for all-nan slices
* `escore` uses `vectorize=True` as it should

### Does this PR introduce a breaking change?

Yes, maybe? The way that `escore` is computed is changed, but for the better

### Other information: