### PR TITLE
Grouper("time", window>1) now throws an error

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,7 @@ Fixes
 ^^^^^
 * For `fastnanquantile`, `POT`, and `xclim` have been added to a new `extras` install recipe. All dependencies can be installed using the ``$ python -m pip install xsdba[all]`` command. Documentation has been added. (:pull:`105`).
 * Several small `dask`-related issues (chunking behaviour, dimension order when broadcasting variables, lazy array preservation) have been fixed. (:issue:`112`, :issue:`113`, :pull:`114`).
+* `Grouper` now throws an error if `group='time'` is used  with `window>1`.
 
 Internal changes
 ^^^^^^^^^^^^^^^^

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,7 +17,7 @@ Fixes
 ^^^^^
 * For `fastnanquantile`, `POT`, and `xclim` have been added to a new `extras` install recipe. All dependencies can be installed using the ``$ python -m pip install xsdba[all]`` command. Documentation has been added. (:pull:`105`).
 * Several small `dask`-related issues (chunking behaviour, dimension order when broadcasting variables, lazy array preservation) have been fixed. (:issue:`112`, :issue:`113`, :pull:`114`).
-* `Grouper` now throws an error if `group='time'` is used  with `window>1`.
+* `Grouper` now throws an error if `group='time'` is used  with `window>1`. (:issue:`104`, :pull:`122`).
 
 Internal changes
 ^^^^^^^^^^^^^^^^

--- a/src/xsdba/base.py
+++ b/src/xsdba/base.py
@@ -141,6 +141,12 @@ class Grouper(Parametrizable):
             by the `main_only` parameter of the `apply` method. If any of these dimensions are absent from the
             DataArrays, they will be omitted.
         """
+        if group == "time" and window > 1:
+            raise ValueError(
+                "The group given is 'time', but the window given is greater than 1. The `group = 'time'` option "
+                "takes the complete series, thus the concept of window is not applicable in this case. When using `group = 'time'`, "
+                "`window=1` is expected."
+            )
         if "." in group:
             dim, prop = group.split(".")
         else:


### PR DESCRIPTION
<!-- Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
  - This PR fixes #xyz
- [ ] (If applicable) Documentation has been added / updated (for bug fixes / features).
- [ ] (If applicable) Tests have been added.
- [ ] CHANGELOG.rst has been updated (with summary of main changes).
  - [ ] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added.

### What kind of change does this PR introduce?

* Throws an error for `Grouper("time", window>1)`

### Does this PR introduce a breaking change?

Yes, an option that didn't make sense is no longer available

### Other information:

.