### PR TITLE
Throw error if group.name=="5D" and method is not MBCn

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,7 @@ Changes
     * New spatial diagnostic to compute the spectral variance of a given field ``xsdba.properties.spectral_variance``. (:pull:`88`).
 * ``xsdba.units.convert_units_to`` now wraps a private function ``_convert_units_to``. (:pull:`145`).
 * ``xsdba.jitter_over_thresh`` is available directly in training methods by passing the `jitter_over_thresh_value` and `jitter_over_thresh_upper_bnd`  arguments. (:pull:`110`).
+* Throw an error if `group=Grouper('5D',window)` if the biasadjust method is not `MBCn`.
 
 Fixes
 ^^^^^

--- a/src/xsdba/adjustment.py
+++ b/src/xsdba/adjustment.py
@@ -78,6 +78,7 @@ class BaseAdjustment(ParametrizableWithDataset):
     _allow_diff_calendars = True
     _allow_diff_training_times = True
     _allow_diff_time_sizes = True
+    _allow_5d_grouping = False
     _attribute = "_xsdba_adjustment"
 
     def __init__(self, *args, _trained=False, **kwargs):
@@ -95,6 +96,12 @@ class BaseAdjustment(ParametrizableWithDataset):
 
         Also raises if :py:attr:`BaseAdjustment._allow_diff_calendars` is False and calendars differ.
         """
+        # Grouper("5D", window) is only a special option for MBCn
+        if not cls._allow_5d_grouping and group.name == "5D":
+            raise NotImplementedError(
+                "`group=Grouper('5D', window)` is a special grouping currently only supported for MBCn."
+            )
+
         for inda in inputs:
             if uses_dask(inda) and len(inda.chunks[inda.get_axis_num(group.dim)]) > 1:
                 raise ValueError(
@@ -1811,6 +1818,7 @@ class MBCn(TrainAdjust):
     _allow_diff_calendars = False
     _allow_diff_training_times = False
     _allow_diff_time_sizes = False
+    _allow_5d_grouping = True
 
     @classmethod
     def _train(

--- a/tests/test_adjustment.py
+++ b/tests/test_adjustment.py
@@ -1231,6 +1231,15 @@ def test_raise_on_multiple_chunks(timelonlatseries):
         EmpiricalQuantileMapping.train(ref, ref, group=Grouper("time.month"))
 
 
+def test_raise_on_5d_grouping(timelonlatseries):
+    attrs_tas = {"units": "K", "kind": ADDITIVE}
+    ref = timelonlatseries(np.arange(730).astype(float), attrs=attrs_tas).chunk(
+        {"time": 365}
+    )
+    with pytest.raises(NotImplementedError):
+        DetrendedQuantileMapping.train(ref, ref, group=Grouper("5D", 1))
+
+
 def test_default_grouper_understood(timelonlatseries):
     attrs_tas = {"units": "K", "kind": ADDITIVE}
     ref = timelonlatseries(np.arange(730).astype(float), attrs=attrs_tas)


### PR DESCRIPTION
<!-- Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
  - This PR fixes #xyz
- [ ] (If applicable) Documentation has been added / updated (for bug fixes / features).
- [ ] (If applicable) Tests have been added.
- [ ] CHANGELOG.rst has been updated (with summary of main changes).
  - [ ] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added.

### What kind of change does this PR introduce?

* `Grouper("5D",window)` is currently only a hack intended for MBCn. Throw an error if users attempt to use this group with another method.

### Does this PR introduce a breaking change?

No

### Other information:
