### PR TITLE
Clip bounds additive space

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,7 +18,7 @@ Changes
 * ``xsdba.units.convert_units_to`` now wraps a private function ``_convert_units_to``. (:pull:`145`).
 * ``xsdba.jitter_over_thresh`` is available directly in training methods by passing the `jitter_over_thresh_value` and `jitter_over_thresh_upper_bnd`  arguments. (:pull:`110`).
 * Throw an error if `group=Grouper('5D',window)` is used with a biasadjust method other than `MBCn`.
-* ``xsdba.processing.to_additive_space`` accepts `clip_to_bounds`, which avoids infinities by ensuring `lower_bound < data < upper_bound`. (:pull:`165`).
+* ``xsdba.processing.to_additive_space`` accepts `clip_next_to_bounds`, which avoids infinities by ensuring `lower_bound < data < upper_bound`. (:pull:`165`).
 
 Fixes
 ^^^^^

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,7 @@ Changes
 * ``xsdba.units.convert_units_to`` now wraps a private function ``_convert_units_to``. (:pull:`145`).
 * ``xsdba.jitter_over_thresh`` is available directly in training methods by passing the `jitter_over_thresh_value` and `jitter_over_thresh_upper_bnd`  arguments. (:pull:`110`).
 * Throw an error if `group=Grouper('5D',window)` is used with a biasadjust method other than `MBCn`.
+* ``xsdba.processing.to_additive_space`` accepts `clip_to_bounds`, which avoids infinities by ensuring `lower_bound < data < upper_bound`. (:pull:`165`).
 
 Fixes
 ^^^^^

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,7 +18,7 @@ Changes
 * ``xsdba.units.convert_units_to`` now wraps a private function ``_convert_units_to``. (:pull:`145`).
 * ``xsdba.jitter_over_thresh`` is available directly in training methods by passing the `jitter_over_thresh_value` and `jitter_over_thresh_upper_bnd`  arguments. (:pull:`110`).
 * Throw an error if `group=Grouper('5D',window)` is used with a biasadjust method other than `MBCn`.
-* ``xsdba.processing.to_additive_space`` accepts `clip_next_to_bounds`, which avoids infinities by ensuring `lower_bound < data < upper_bound`. (:pull:`165`).
+* ``xsdba.processing.to_additive_space`` accepts `clip_next_to_bounds`, which avoids infinities by ensuring `lower_bound < data < upper_bound`. (:issue:`164`, :pull:`165`).
 
 Fixes
 ^^^^^

--- a/src/xsdba/processing.py
+++ b/src/xsdba/processing.py
@@ -540,7 +540,7 @@ def to_additive_space(
     trans : {'log', 'logit'}
         The transformation to use. See notes.
     clip_to_bounds : bool
-        If `True`, values are clipped to ensure data > lower_bound  and data < upper_bound (if specified).
+        If `True`, values are clipped to ensure `data > lower_bound`  and `data < upper_bound` (if specified).
         Defaults to `False`.
 
     See Also

--- a/src/xsdba/processing.py
+++ b/src/xsdba/processing.py
@@ -541,7 +541,7 @@ def to_additive_space(
         The transformation to use. See notes.
     clip_to_bounds : bool
         If `True`, values are clipped to ensure `data > lower_bound`  and `data < upper_bound` (if specified).
-        Defaults to `False`.
+        Defaults to `False`. `data` must be in the range [lower_bound, upper_bound], else an error is thrown.
 
     See Also
     --------
@@ -606,7 +606,7 @@ def to_additive_space(
             raise ValueError(
                 "The input dataset contains values outside of the range [lower_bound, upper_bound] "
                 "(with upper_bound given by infinity is not specified). Clipping the values to the range "
-                "]lower_bound, upper_bound[ will silence this problem. Check if the bounds are taken appropriately or "
+                "]lower_bound, upper_bound[ is not allowed in this case. Check if the bounds are taken appropriately or "
                 "if your input dataset has unphysical values."
             )
 

--- a/src/xsdba/processing.py
+++ b/src/xsdba/processing.py
@@ -519,7 +519,7 @@ def to_additive_space(
     lower_bound: str,
     upper_bound: str | None = None,
     trans: str = "log",
-    clip_to_bounds: bool = False,
+    clip_next_to_bounds: bool = False,
 ):
     r"""
     Transform a non-additive variable into an additive space by the means of a log or logit transformation.
@@ -539,7 +539,7 @@ def to_additive_space(
         The data should only have values strictly smaller than this bound.
     trans : {'log', 'logit'}
         The transformation to use. See notes.
-    clip_to_bounds : bool
+    clip_next_to_bounds : bool
         If `True`, values are clipped to ensure `data > lower_bound`  and `data < upper_bound` (if specified).
         Defaults to `False`. `data` must be in the range [lower_bound, upper_bound], else an error is thrown.
 
@@ -578,7 +578,7 @@ def to_additive_space(
     This will thus produce `Infinity` and `NaN` values where :math:`X == b_-` or :math:`X == b_+`.
     We recommend using :py:func:`jitter_under_thresh` and :py:func:`jitter_over_thresh` to remove those issues.
 
-    If :math:`X \in [b_-, b_+]`, `clip_to_bounds` can be set to `True`, and boundary values will be slightly changed (with the smallest float32
+    If :math:`X \in [b_-, b_+]`, `clip_next_to_bounds` can be set to `True`, and boundary values will be slightly changed (with the smallest float32
     increment) to ensure that :math:`X \in ]b_-, b_+[`.
 
     References
@@ -601,11 +601,11 @@ def to_additive_space(
             raise NotImplementedError("`trans` must be one of 'log' or 'logit'.")
 
     # clip bounds
-    if clip_to_bounds:
+    if clip_next_to_bounds:
         if (data < lower_bound).any() or (data > (upper_bound or np.nan)).any():
             raise ValueError(
                 "The input dataset contains values outside of the range [lower_bound, upper_bound] "
-                "(with upper_bound given by infinity is not specified). Clipping the values to the range "
+                "(with upper_bound given by infinity if it is not specified). Clipping the values to the range "
                 "]lower_bound, upper_bound[ is not allowed in this case. Check if the bounds are taken appropriately or "
                 "if your input dataset has unphysical values."
             )

--- a/src/xsdba/processing.py
+++ b/src/xsdba/processing.py
@@ -578,6 +578,9 @@ def to_additive_space(
     This will thus produce `Infinity` and `NaN` values where :math:`X == b_-` or :math:`X == b_+`.
     We recommend using :py:func:`jitter_under_thresh` and :py:func:`jitter_over_thresh` to remove those issues.
 
+    If :math:`X \in [b_-, b_+]`, `clip_to_bounds` can be set to `True`, and boundary values will be slightly changed (with the smallest float32
+    increment) to ensure that :math:`X \in ]b_-, b_+[`.
+
     References
     ----------
     :cite:cts:`alavoine_distinct_2022`.
@@ -599,6 +602,14 @@ def to_additive_space(
 
     # clip bounds
     if clip_to_bounds:
+        if (data < lower_bound).any() or (data > (upper_bound or np.nan)).any():
+            raise ValueError(
+                "The input dataset contains values outside of the range [lower_bound, upper_bound] "
+                "(with upper_bound given by infinity is not specified). Clipping the values to the range "
+                "]lower_bound, upper_bound[ will silence this problem. Check if the bounds are taken appropriately or "
+                "if your input dataset has unphysical values."
+            )
+
         low = np.nextafter(lower_bound, np.inf, dtype=np.float32)
         high = (
             None

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -253,7 +253,7 @@ def test_to_additive(timeseries):
 
 def test_to_additive_clipping(timeseries):
     # log
-    pr = timeseries(np.array([-1]), units="kg m^-2 s^-1")
+    pr = timeseries(np.array([0]), units="kg m^-2 s^-1")
     prlog = to_additive_space(
         pr, lower_bound="0 kg m^-2 s^-1", trans="log", clip_next_to_bounds=True
     )

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -251,6 +251,34 @@ def test_to_additive(timeseries):
     assert hurslogit2.attrs["xsdba_transform_upper"] == 600.0
 
 
+def test_to_additive_clipping(timeseries):
+    # log
+    pr = timeseries(np.array([-1]), units="kg m^-2 s^-1")
+    prlog = to_additive_space(
+        pr, lower_bound="0 kg m^-2 s^-1", trans="log", clip_next_to_bounds=True
+    )
+    assert np.isfinite(prlog).all()
+
+    with xr.set_options(keep_attrs=True):
+        pr1 = pr + 1
+    lower_bound = "1 kg m^-2 s^-1"
+    prlog2 = to_additive_space(
+        pr1, trans="log", lower_bound=lower_bound, clip_next_to_bounds=True
+    )
+    assert np.isfinite(prlog2).all()
+
+    # logit
+    hurs = timeseries(np.array([0, 100]), units="%")
+    hurslogit = to_additive_space(
+        hurs,
+        lower_bound="0 %",
+        trans="logit",
+        upper_bound="100 %",
+        clip_next_to_bounds=True,
+    )
+    assert np.isfinite(hurslogit).all()
+
+
 def test_from_additive(timeseries):
     # log
     pr = timeseries(np.array([0, 1e-5, 1, np.e**10]), units="mm/d")


### PR DESCRIPTION
<!-- Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
  - This PR fixes #xyz
- [ ] (If applicable) Documentation has been added / updated (for bug fixes / features).
- [x] (If applicable) Tests have been added.
- [x] CHANGELOG.rst has been updated (with summary of main changes).
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added.

### What kind of change does this PR introduce?

* Additive_space  defines `lower_bound` and possible `upper_bound`. `data` should be  $low < data < high$, else infinities arise. It sometimes happens we have  $low \leq data \leq high$ (e.g. hurs at exactly 100%). For convenience, to_additive_space can now transform $data \in [low, high] \to ]low, high[$ by adding/subtracting the smallest float32 increments. If `data < low | data > high` this throws an error if we try this procedure. We don't want the clipping to put problems under the rug

### Does this PR introduce a breaking change?

No

### Other information:

@juliettelavoie  I think it makes sense to have this directly in xsdba. Here, I don't specify any clipping bounds, I think it's better to just use whatever {lower,upper}_bound are given

In this way, xscen could simply set `clip_to_bounds = True` in the arguments of `to_additive_space`
