### PR TITLE
cluster_thresh in ExtremeValues as a Quantified

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,7 +21,7 @@ Changes
 * ``xsdba.processing.to_additive_space`` accepts `clip_next_to_bounds`, which avoids infinities by ensuring `lower_bound < data < upper_bound`. (:issue:`164`, :pull:`165`).
 * Allow nan values in ``xsdba.measures.rmse`` and ``xsdba.measures.mae``. (:pull:`170`).
 * The adaptation of frequencies through `adapt_freq_thresh_value` is now applied in the adjusting step as well. (:pull:`160`).
-* ``xsdba.adjustment.ExtremeValues`` now accepts a DataArray for `cluster_thresh`, letting specify distinct thresholds for multiple locations.
+* ``xsdba.adjustment.ExtremeValues`` now accepts a DataArray for `cluster_thresh`, letting specify distinct thresholds for multiple locations. (:pull:`179`).
 
 Fixes
 ^^^^^

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,7 @@ Changes
 * ``xsdba.processing.to_additive_space`` accepts `clip_next_to_bounds`, which avoids infinities by ensuring `lower_bound < data < upper_bound`. (:issue:`164`, :pull:`165`).
 * Allow nan values in ``xsdba.measures.rmse`` and ``xsdba.measures.mae``. (:pull:`170`).
 * The adaptation of frequencies through `adapt_freq_thresh_value` is now applied in the adjusting step as well. (:pull:`160`).
+* ``xsdba.adjustment.ExtremeValues`` now accepts a DataArray for `cluster_thresh`, letting specify distinct thresholds for multiple locations.
 
 Fixes
 ^^^^^
@@ -32,6 +33,7 @@ Internal changes
 ^^^^^^^^^^^^^^^^
 * The `tox` and CI configurations now support the installation of `SBCK` and `Eigen3` for testing purposes. (:pull:`139`).
 * The `coveralls` tox keyword has been renamed to `coverage` to avoid confusion with the `coveralls` service. (:pull:`139`).
+* The order of arguments in the following private functions was changed: ``xsdba._adjustment.{_fit_on_cluster,_fit_cluster_and_cdf, _extremes_train_1d}``.
 
 .. _changes_0.4.0:
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,7 +21,7 @@ Changes
 * ``xsdba.processing.to_additive_space`` accepts `clip_next_to_bounds`, which avoids infinities by ensuring `lower_bound < data < upper_bound`. (:issue:`164`, :pull:`165`).
 * Allow nan values in ``xsdba.measures.rmse`` and ``xsdba.measures.mae``. (:pull:`170`).
 * The adaptation of frequencies through `adapt_freq_thresh_value` is now applied in the adjusting step as well. (:pull:`160`).
-* ``xsdba.adjustment.ExtremeValues`` now accepts a DataArray for `cluster_thresh`, letting specify distinct thresholds for multiple locations. (:pull:`179`).
+* ``xsdba.adjustment.ExtremeValues`` now accepts a DataArray for `cluster_thresh`, letting specify distinct thresholds for multiple locations. (:issue:`177`, :pull:`179`).
 
 Fixes
 ^^^^^


### PR DESCRIPTION
<!-- Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
  - This PR fixes #xyz
- [x] (If applicable) Documentation has been added / updated (for bug fixes / features).
- [x] (If applicable) Tests have been added.
- [x] CHANGELOG.rst has been updated (with summary of main changes).
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added.

### What kind of change does this PR introduce?

* `cluster_thresh` is now a Quantified, so that different thresholds can be specified.

### Does this PR introduce a breaking change?

Not in public functions. In some private functions, I changed the order of arguments. There is an apply_ufunc and it made more sense to put cluster_thresh upfront since it's now a DataArray too.

### Other information:

