### PR TITLE
Add changelog entries missing from #194

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -56,7 +56,7 @@ Fixes
 * Fixed an issue with attribute fields added to normalized arrays under newer `xarray` versions. (:pull:`223`).
 * ``xsdba.processing.spectral_filter`` now works with a `lambda_long` and `lambda_short` that are not `None`. (:pull:`220`).
 * Prepend history of operations within dataset attributes instead of appending them. (:pull:`238`).
-* ``xsdba._processing._adapt_freq`` now avoids inserting nans. This was solved using `(dP0 <= 0)| (dP0.isnull())` and not `dP0 < 0` as a condition. (:pull:`239`,:issue:`248`, :pull:`249`).
+* ``xsdba._processing._adapt_freq`` now avoids inserting nans. This was solved using `(dP0 <= 0)| (dP0.isnull())` and not `dP0 < 0` as a condition. (:pull:`239`, :issue:`248`, :pull:`249`).
 * More edge cases and compatibility with `numpy <2.0` were fixed  to ensure ``xsdba.processing.to_additive_space`` does not yield singular values in the log / logit transforms in relation with the machine resolution. (:pull:`194`).
 * ``xsdba.properties.decorrelation_length`` now handles all-nan slices correctly. (:issue:`255`, :pull:`256`).
 


### PR DESCRIPTION
### What kind of change does this PR introduce?

* Adds missing information to the changelog of v0.6.0

### Does this PR introduce a breaking change?

Not really.

### Other information:

Going through the stale branches and happened upon this. @coxipi, can you confirm that this should have been in the release?